### PR TITLE
1 add package filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ mainNpmFiles('**/*.js');
 See, that was easy. Missed anything ? Check the source, it's a fairly small file :)
 
 Here are some options you can send along:
+* `package` - Only the specified package. Optional.
 * `nodeModules` - Location of your modules, defaults to `./node_modules`;
 * `pkgJson` - Location of your package.json, defaults to `./package.json`;
 * `onlySpecified` - Decides if you only want to retrieve the files specified by the package.json or just all files from the package, ah yeah both still have the glob applied of course, defaults to `true`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const defaultOptions = {
   onlyMain: false
 };
 
-module.exports = function(filter, customOpts) {
+module.exports = function (filter, customOpts) {
   let allFiles = [];
 
   const options = Object.assign(defaultOptions, customOpts);
@@ -26,6 +26,9 @@ module.exports = function(filter, customOpts) {
 
   //Apply the glob to all the dependencies in the package.json
   for (const dependency in dependencies) {
+
+    if (options.package && dependency != options.package) continue;
+
     const modulePath = join(options.nodeModules, dependency);
 
     //Read the package.json of a dependency

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-npm-files",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Searches for static files in npm packages",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've added the ability to filter for a specific package. Feel free to modify the implementation if you think it should be done differently. I simply opted to add a package field to the customOpts parameter. I didn't write any unit tests for this, as I'm not familiar with JavaScript unit testing.